### PR TITLE
Update template's test dependencies

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -20,7 +20,7 @@
     "machine": "^12.2.5"
   },
   "devDependencies": {
-    "test-machinepack-mocha": "^2.1.5"
+    "test-machinepack-mocha": "^3.0.0"
   },
   "machinepack": {
     "friendlyName": <%= JSON.stringify(friendlyName) || '""' %>,

--- a/app/templates/machines/say-hello.js
+++ b/app/templates/machines/say-hello.js
@@ -19,8 +19,6 @@ module.exports = {
 
   },
 
-  defaultExit: 'success',
-
   exits: {
 
     error: {
@@ -28,7 +26,7 @@ module.exports = {
     },
 
     success: {
-      example:  {
+      example: {
         numLettersInName: 4,
         secretCode: "e9ec627220bc9e8ca66f916b7fba92f3"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-machinepack",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "Yeoman generator for machinepacks.",
   "license": "MIT",
   "main": "app/index.js",

--- a/test/test-app.js
+++ b/test/test-app.js
@@ -6,6 +6,7 @@ var helpers = require('yeoman-generator').test;
 var os = require('os');
 
 describe('machinepack:app', function () {
+  this.timeout(30000);
   before(function (done) {
     helpers.run(path.join(__dirname, '../app'))
       .inDir(path.join(os.tmpdir(), './temp-test'))
@@ -18,7 +19,7 @@ describe('machinepack:app', function () {
 
   it('creates files', function () {
     assert.file([
-      'bower.json',
+      // 'bower.json',
       'package.json',
       '.editorconfig',
       '.jshintrc'


### PR DESCRIPTION
I wasn't able to run 'npm test' in the generated project after following the instructions from [here](http://node-machine.org/implementing/Getting-Started#installing-the-command-line-tools).

Looks like updating `test-machinepack-mocha` does the business. Was going to bump the `machine` version as well but [machinepack](https://github.com/node-machine/machinepack) didn't like that (can't `exec` stuff).

Also added the timeout in `test/test-app.js` as it was running the generator then timing out before there was a chance to fill out the questions it asks. Not sure about the `bower.json` file in there - I don't see that it should actually be coming from anywhere unless I missed some secret voodoo.