### PR TITLE
[patch] Gitter 'Join Chat' svg fix in README.MD

### DIFF
--- a/app/templates/README.md
+++ b/app/templates/README.md
@@ -32,7 +32,7 @@ $ npm install <%= moduleName %>
 
 For the latest usage documentation, version information, and test status of this module, see <a href="http://node-machine.org/<%= moduleName %>" title="<%= description %> (for node.js)">http://node-machine.org/<%= moduleName %></a>.  The generated manpages for each machine contain a complete reference of all expected inputs, possible exit states, and example return values.  If you need more help, or find a bug, jump into [Gitter](https://gitter.im/node-machine/general) or leave a message in the project [newsgroup](https://groups.google.com/forum/?hl=en#!forum/node-machine).
 
-## About  &nbsp; [![Gitter](https://badges.gitter.im/Join Chat.svg)](https://gitter.im/node-machine/general?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
+## About  &nbsp; [![Gitter](https://badges.gitter.im/Join_Chat.svg)](https://gitter.im/node-machine/general?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
 This is a [machinepack](http://node-machine.org/machinepacks), an NPM module which exposes a set of related Node.js [machines](http://node-machine.org/spec/machine) according to the [machinepack specification](http://node-machine.org/spec/machinepack).
 Documentation pages for the machines contained in this module (as well as all other NPM-hosted machines for Node.js) are automatically generated and kept up-to-date on the <a href="http://node-machine.org" title="Public machine registry for Node.js">public registry</a>.


### PR DESCRIPTION
@mikermcneil Hello Mike! 

I noticed the repo was a bit stale, so I mention you to ensure you get the heads-up about this PR. 

When I discovered the concept around Node-machines today I was browsing through a lot of the published machinepacks and noticed that most, if not all, repos had a broken image-link in their README.MD. Researching this I found out that the markdown for including the Gitter 'Join Chat' SVG contained a space in the URL which broke the link, causing the ugly headings to appear in all the generated machinepacks' README.MD files.

This patch just fixes that small bug in the template, but I still hope you find the contribution useful.

Thanks for your time!

Cheers!